### PR TITLE
PSDscResources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.userosscache
 *.sln.docstates
 
+# Vagrant files for running Windows VMs on MacOS
+.vagrant/
+.vagrantfile
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/External DSC Resources/cNtfsAccessControl/Examples/Sample_cNtfsPermissionEntry.ps1
+++ b/External DSC Resources/cNtfsAccessControl/Examples/Sample_cNtfsPermissionEntry.ps1
@@ -16,7 +16,7 @@ Configuration Sample_cNtfsPermissionEntry
     )
 
     Import-DscResource -ModuleName cNtfsAccessControl
-    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName PSDscResoures
 
     File TestDirectory
     {

--- a/External DSC Resources/cNtfsAccessControl/README.md
+++ b/External DSC Resources/cNtfsAccessControl/README.md
@@ -94,7 +94,7 @@ Configuration Sample_cNtfsPermissionEntry
     )
 
     Import-DscResource -ModuleName cNtfsAccessControl
-    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName PSDscResoures
 
     File TestDirectory
     {
@@ -186,7 +186,7 @@ Configuration Sample_cNtfsPermissionsInheritance
     )
 
     Import-DscResource -ModuleName cNtfsAccessControl
-    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName PSDscResoures
 
     File TestDirectory
     {

--- a/External DSC Resources/xScheduledTask/1.0.0.6/DSCResources/xScheduledTask/test.ps1
+++ b/External DSC Resources/xScheduledTask/1.0.0.6/DSCResources/xScheduledTask/test.ps1
@@ -1,7 +1,7 @@
 ﻿Configuration Test
 {
 	Import-DscResource -ModuleName xScheduledTask
-    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+    Import-DscResource -ModuleName 'PSDscResoures'
     Import-DSCResource -ModuleName 'AuditPolicyDSC'
     Import-DSCResource -ModuleName 'SecurityPolicyDSC'
     Import-DSCResource -ModuleName 'BaselineManagement'

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ automatically installed:
 - SecurityPolicyDSC
 - AuditPolicyDSC
 - GPRegistrPolicyParser
+- PSDscResoureces
 
 To install the latest stable version, use the following command.
 

--- a/src/BaselineManagement.psd1
+++ b/src/BaselineManagement.psd1
@@ -12,7 +12,7 @@
 RootModule = 'BaselineManagement.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.9.0'
+ModuleVersion = '2.10.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -51,9 +51,10 @@ PowerShellVersion = '5.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'AuditPolicyDSC'; ModuleVersion = '1.4.0.0'; },
-               @{ModuleName = 'SecurityPolicyDSC'; ModuleVersion = '2.8.0.0'; },
-               @{ModuleName = 'GPRegistryPolicyParser'; ModuleVersion = '0.2'; })
+RequiredModules = @(@{ModuleName = 'AuditPolicyDSC'; ModuleVersion = '1.4.0'; },
+               @{ModuleName = 'SecurityPolicyDSC'; ModuleVersion = '2.10.0'; },
+               @{ModuleName = 'GPRegistryPolicyParser'; ModuleVersion = '0.2'; },
+               @{ModuleName = 'PSDscResoureces'; ModuleVersion = '2.12.0'})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -98,13 +99,13 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+        Tags = @('DesiredStateConfiguration','DSC','GuestConfiguration','GroupPolicy')
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        LicenseUri = 'https://github.com/microsoft/BaselineManagement/blob/master/LICENSE'
 
         # A URL to the main website for this project.
-        # ProjectUri = ''
+        ProjectUri = 'https://github.com/microsoft/baselinemanagement'
 
         # A URL to an icon representing this module.
         # IconUri = ''

--- a/src/BaselineManagement.psm1
+++ b/src/BaselineManagement.psm1
@@ -172,7 +172,7 @@ function ConvertFrom-GPO
     Begin
     {
         # These are the DSC Resources needed for NON-preference based GPOS.
-        $NeededModules = 'PSDesiredStateConfiguration', 'AuditPolicyDSC', 'SecurityPolicyDSC', 'PowerShellAccessControl'
+        $NeededModules = 'PSDscResoures', 'AuditPolicyDSC', 'SecurityPolicyDSC', 'PowerShellAccessControl'
 
         # Start tracking Processing History.
         Clear-ProcessingHistory
@@ -810,7 +810,7 @@ Function ConvertFrom-SCM
     # Create the Configuration String
     $ConfigString = Write-DSCString -Configuration -Name $ConfigName -Comment $BaselineComment
     # Add any resources
-    $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDesiredStateConfiguration, AuditPolicyDSC, SecurityPolicyDSC
+    $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDscResoures, AuditPolicyDSC, SecurityPolicyDSC
     # Add Node Data
     $ConfigString += Write-DSCString -Node -Name $ComputerName
 
@@ -1042,7 +1042,7 @@ function ConvertFrom-ASC
         # Create the Configuration String
         $ConfigString = Write-DSCString -Configuration -Name $ConfigName
         # Add any resources
-        $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDesiredStateConfiguration, AuditPolicyDSC, SecurityPolicyDSC
+        $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDscResoures, AuditPolicyDSC, SecurityPolicyDSC
         # Add Node Data
         $ConfigString += Write-DSCString -Node -Name $computername
 
@@ -1464,7 +1464,7 @@ function ConvertFrom-Excel
         # Create the Configuration String
         $ConfigString = Write-DSCString -Configuration -Name DSCFromCSV
         # Add any resources
-        $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDesiredStateConfiguration, AuditPolicyDSC, SecurityPolicyDSC
+        $ConfigString += Write-DSCString -ModuleImport -ModuleName PSDscResoures, AuditPolicyDSC, SecurityPolicyDSC
         # Add Node Data
         $ConfigString += Write-DSCString -Node -Name $computername
 

--- a/tests/unit/Helpers/Functions.tests.ps1
+++ b/tests/unit/Helpers/Functions.tests.ps1
@@ -10,7 +10,7 @@ $Enumerations = Get-Item -Path (Join-Path -Path $script:SourceRoot -ChildPath "H
 . $Functions.FullName
 . $Enumerations.FullName
 
-Import-Module PSDesiredStateConfiguration -Force
+Import-Module PSDscResoures -Force
 
 Describe "DSC String Helper Tests" {
     Context "Write-DSCString" {
@@ -20,7 +20,7 @@ Describe "DSC String Helper Tests" {
         Mock Get-DSCResource -ParameterFilter { $Module -eq "TestModule_02"} -Verifiable { return [psobject]@{Name="TestResource_02";Properties=@(@{Name="Name";IsMandatory=$true}, @{Name="Value";IsMandatory=$true})}}
 
         $CONFIG_Params = @{Configuration=$true;Name="TestConfig"}
-        $CONFIG_ModuleParams = @{ModuleName = @("PSDesiredStateConfiguration");ModuleImport=$true}
+        $CONFIG_ModuleParams = @{ModuleName = @("PSDscResoures");ModuleImport=$true}
         $CONFIG_Node = @{Node=$true;Name="localhost"}
         $CONFIG_ResourceParams = @{Resource=$true;Type="Registry";Name="Test";Parameters=@{Key="HKLM:\SOFTWARE";ValueName = "TestResource";ValueData="Test";ValueType="DWORD" }}
         $CONFIG_Invoke = @{InvokeConfiguration=$true;Name="TestConfig";OutputPath=$(Join-Path -Path "C:\Temp" -ChildPath Output)}
@@ -98,7 +98,7 @@ Describe "DSC String Helper Tests" {
         $Configuration = @"
 Configuration PesterTest
 {
-    Import-DSCResource -ModuleName PSDesiredStateConfiguration
+    Import-DSCResource -ModuleName PSDscResoures
     Node localhost
     {
         Service Spooler
@@ -114,7 +114,7 @@ PesterTest -OutputPath $($script:TestSourceRoot)
         $Configuration_ERROR = @"
 Configuration PesterTest
 {
-    Import-DSCResource -ModuleName PSDesiredStateConfiguration
+    Import-DSCResource -ModuleName PSDscResoures
     Node localhost
     {
         Service Spooler


### PR DESCRIPTION
Since all new DSC resources updates are going in to the supported module [PSDscResources](https://github.com/powershell/psdscresources) rather than 'PSDesiredStateConfiguration', recommending a switch.

This does require some minor code review since I have attempted to make the switch anywhere the modules are used to load resources, but PSDesiredStateConfiguration module is required in non-Windows environments to support compilation.
