### PR TITLE
Registry Force

### DIFF
--- a/src/Parsers/GPO/Registry.ps1
+++ b/src/Parsers/GPO/Registry.ps1
@@ -372,6 +372,7 @@ Function Write-GPORegistryPOLData
     {
         $regHash.ValueData = $Data.ValueData
     }
+    $regHash.Force = $true
 
     Update-RegistryHashtable $regHash
     


### PR DESCRIPTION
After POCing this with DSC and GC both, and recalling that you brought up this issue in the past, I think the right think to do for Registry type is to use Force = $true. Otherwise on Set scenarios, DSC encounters issues either if the Key doesn't exist or if the value already exists with some other value.

Another thing to consider would be introducing a parameter that switches RegistryForce on/off. I'm not sure we need it though. This seems like something that could easily be removed by find/replace if it is not the intended behavior.